### PR TITLE
Adding toggle support

### DIFF
--- a/util/state.js
+++ b/util/state.js
@@ -20,6 +20,7 @@ let messages = []
 let filteredMessages = []
 let viewableMessages = []
 let privateRecipients = []
+let lastPrivateRecipient = []
 let filteredPrivateRecipients = []
 let notifications = []
 let currentMode = constants.MODE.PUBLIC
@@ -269,10 +270,12 @@ const setPrivateRecipients = (recipients) => {
   refreshFilteredPrivateRecipients()
   setPrivateMode()
 }
+const getLastPrivateRecipient = () => lastPrivateRecipient
 const refreshFilteredPrivateRecipients = () => {
   filteredPrivateRecipients = privateRecipients.filter(pr => pr !== getMe()).map(getAuthor)
 }
 const resetPrivateRecipients = () => {
+  lastPrivateRecipient = privateRecipients
   privateRecipients = []
   privateMessageRoot = null
   refreshFilteredPrivateRecipients()
@@ -336,6 +339,7 @@ module.exports = {
   getPrivateMessageRoot,
   getPrivateRecipients,
   getPrivateRecipientsNotMe,
+  getLastPrivateRecipient,
   refreshFilteredPrivateRecipients,
   setPrivateRecipients,
   resetPrivateRecipients,

--- a/util/ui/input.js
+++ b/util/ui/input.js
@@ -83,4 +83,15 @@ input.on('ctrl-u', () => {
   state.setPrivateRecipients(unread)
 })
 
+input.on('ctrl-t', () => {
+  if (state.isPrivateMode()) {
+    state.setPublicMode()
+    return
+  }
+
+  if (state.getLastPrivateRecipient().length) {
+    state.setPrivateRecipients(state.getLastPrivateRecipient())
+  }
+})
+
 module.exports = input


### PR DESCRIPTION
Users can now have the ability to toggle between public mode and their last viewed private chat by hitting ctrl + t . This is effective when combined with ctrl + u in order to easily check all private message and get back to public without typing anything.