### PR TITLE
Upgrade clor to turbocolor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -656,10 +656,15 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
-    "clorox": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clorox/-/clorox-1.0.3.tgz",
-      "integrity": "sha512-w3gKAUKMJYmmaJyc+p+iDrDtLvsFasrx/y6/zWo2U1TZfsz3y4Vl4T9PHCZrOwk1eMTOSRI6xHdpDR4PhTdy8Q=="
+    "clp": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/clp/-/clp-4.0.10.tgz",
+      "integrity": "sha512-V0fkt+ZL220YUUl8hgxxB6hQeOU8YsdfZ8jyJbanu77z3wri4CmYcmXdlJWjclWM9ASzXVps2eyVO616JcpxaA==",
+      "requires": {
+        "is-number": "^2.1.0",
+        "last-char": "^1.3.1",
+        "match-it": "^1.0.0"
+      }
     },
     "co": {
       "version": "3.1.0",
@@ -2968,6 +2973,11 @@
         "is-buffer": "^1.1.5"
       }
     },
+    "last-char": {
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/last-char/-/last-char-1.3.9.tgz",
+      "integrity": "sha512-8jsWryUJCx06lnQCV+XjnHd4QxIvH3Flvzb9GDgA4iwkzj8VKl2iEP0IHrVJ+Ez1FWSt92BykXUDpn/f1CD+Mw=="
+    },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
@@ -3278,6 +3288,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-0.4.0.tgz",
       "integrity": "sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE="
+    },
+    "match-it": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/match-it/-/match-it-1.0.7.tgz",
+      "integrity": "sha1-tczwmRob1Z6CvtTN1MgFcT9AeRU="
     },
     "math-random": {
       "version": "1.0.1",
@@ -5728,6 +5743,11 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "turbocolor": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/turbocolor/-/turbocolor-2.2.0.tgz",
+      "integrity": "sha512-cv+WcDwMuplBEk53EpQ08nS1uX61FgrXWG/da4Efd0O57NFL3aEKqay/S9gKUZPuquf3C+LtaiSbmsZxHPf5cg=="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "standard": "^11.0.1"
   },
   "dependencies": {
-    "clorox": "^1.0.3",
+    "turbocolor": "^2.2.0",
     "clp": "^4.0.10",
     "date-fns": "^1.29.0",
     "diffy": "^2.0.0",

--- a/util/ui/header.js
+++ b/util/ui/header.js
@@ -1,4 +1,4 @@
-const c = require('clorox')
+const tc = require('turbocolor')
 const state = require('../state')
 
 // header describing mode and potentially private recipients
@@ -14,8 +14,8 @@ const header = () => {
   const notification = state.getLastNotification() || []
   const notificationRecipients = notification ? notification.map(state.getAuthor).join(', ') : ''
   const rightHeaderText = notificationRecipients && `Private msg from: ${notificationRecipients}`
-  const leftHeader = isPrivate ? `${c.bgBlack.white(leftHeaderText)}` : `${c.bgWhite.black(leftHeaderText)}`
-  const rightHeader = `${c.bgYellow.black(rightHeaderText)}`
+  const leftHeader = isPrivate ? tc.bgBlack.white(leftHeaderText) : tc.bgWhite.black(leftHeaderText)
+  const rightHeader = tc.bgYellow.black(rightHeaderText)
   const spacerWidth = currentWidth - leftHeaderText.length - rightHeaderText.length
   const spacer = ' '.repeat(spacerWidth > 0 ? spacerWidth : 1)
   return `${leftHeader}${spacer}${rightHeader}`

--- a/util/ui/input.js
+++ b/util/ui/input.js
@@ -1,4 +1,4 @@
-const c = require('clorox')
+const tc = require('turbocolor')
 const Input = require('diffy/input')
 const state = require('../state')
 const commander = require('../commander')
@@ -10,7 +10,7 @@ const client = require('../client')
 let tabCompleter = null
 
 const inputStyle = (start, cursor, end) =>
-  `${start}${c.white.bold('|')}${cursor || ''}${end}`
+  `${start}${tc.white.bold('|')}${cursor || ''}${end}`
 
 const input = Input({ style: inputStyle })
 

--- a/util/ui/printer.js
+++ b/util/ui/printer.js
@@ -1,4 +1,4 @@
-const c = require('clorox')
+const tc = require('turbocolor')
 const format = require('date-fns/format')
 const render = require('./renderer')
 const state = require('../state')
@@ -12,7 +12,7 @@ const highlightMentions = (text) => {
     state.getMeNames().forEach((me) => {
       highlighted = highlighted.split(' ').map((word) => {
         if (word === me) {
-          return `${c.bgMagenta.black(word)}`
+          return tc.bgMagenta.black(word)
         }
         return word
       }).join(' ')
@@ -24,8 +24,8 @@ const highlightMentions = (text) => {
 const message = (m) => {
   const msg = m.value
   const fromMe = msg.author === state.getMe()
-  const authorText = () => c.bold[fromMe ? 'green' : color(msg.author)](state.getAuthor(msg.author))
-  const timeText = `${c.gray.dim(format(msg.timestamp, constants.TIME_FORMAT))}`
+  const authorText = () => tc.bold[fromMe ? 'green' : color(msg.author)](state.getAuthor(msg.author))
+  const timeText = tc.gray.dim(format(msg.timestamp, constants.TIME_FORMAT))
   const renderedMsg = render(msg.content.text)
 
   const currentWidth = state.getWidth()
@@ -52,9 +52,9 @@ const message = (m) => {
 const action = (m) => {
   const msg = m.value
   const fromMe = msg.author === state.getMe()
-  const authorText = () => c.bold[fromMe ? 'green' : color(msg.author)](state.getAuthor(msg.author))
-  const timeText = `${c.gray.dim(format(msg.timestamp, constants.TIME_FORMAT))}`
-  const renderedMsg = c.bold[fromMe ? 'green' : color(msg.author)](render(msg.content.text))
+  const authorText = () => tc.bold[fromMe ? 'green' : color(msg.author)](state.getAuthor(msg.author))
+  const timeText = tc.gray.dim(format(msg.timestamp, constants.TIME_FORMAT))
+  const renderedMsg = tc.bold[fromMe ? 'green' : color(msg.author)](render(msg.content.text))
 
   const currentWidth = state.getWidth()
 
@@ -76,9 +76,9 @@ const action = (m) => {
 
 const system = (msg) => {
   return state.pushSystemMessage({
-    text: () => `${`${c.bold.yellow(msg)}`}`,
+    text: () => tc.bold.yellow(msg),
     rawText: msg,
-    time: `${`${c.gray.dim(format(Date.now(), constants.TIME_FORMAT))}`}`,
+    time: tc.gray.dim(format(Date.now(), constants.TIME_FORMAT)),
     rawTime: Date.now()
   })
 }
@@ -86,9 +86,9 @@ const system = (msg) => {
 const error = (error) => {
   const msg = error.message
   return state.pushSystemMessage({
-    text: () => `${`${c.bold.bgRed.white(msg)}`}`,
+    text: () => tc.bold.bgRed.white(msg),
     rawText: msg,
-    time: `${`${c.gray.dim(format(Date.now(), constants.TIME_FORMAT))}`}`,
+    time: tc.gray.dim(format(Date.now(), constants.TIME_FORMAT)),
     rawTime: Date.now()
   })
 }


### PR DESCRIPTION
Hi @stripedpajamas! I deprecated clor and rebranded it some time ago. This PR upgrades you to its latest and [faster](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks) incarnation: turbocolor. In turbocolor, style methods return strings, so we don't need to coerce everything to a string.

Let me know if this looks good to you. Cheers! 👋 