### PR TITLE
Fix lint errors

### DIFF
--- a/util/commander.js
+++ b/util/commander.js
@@ -58,7 +58,7 @@ module.exports = (input) => new Promise((resolve, reject) => {
     // /me status (action message in IRC land)
     case '/me': {
       const restOfLine = line.slice(1).join(' ')
-      
+
       return core.commands.me(restOfLine)
         .then(resolve)
         .catch(printer.error)
@@ -100,7 +100,7 @@ module.exports = (input) => new Promise((resolve, reject) => {
     // /quit leaves private mode if in it
     case '/q':
     case '/quit': {
-      core.commands.quit()
+      return core.commands.quit()
         .then(resolve)
         .catch(reject)
     }

--- a/util/constants.js
+++ b/util/constants.js
@@ -50,7 +50,6 @@ module.exports = {
     unblock: 'To unblock someone: /unblock @id',
     '/unblock': 'To unblock someone: /unblock @id',
 
-
     whois: 'To look up someone\'s id: /whois name',
     '/whois': 'To look up someone\'s id: /whois name',
 

--- a/util/state.js
+++ b/util/state.js
@@ -130,5 +130,5 @@ module.exports = {
   getSystemMessage,
   resetSystemMessage,
   getLastInput,
-  setLastInput,
+  setLastInput
 }

--- a/util/tabComplete.js
+++ b/util/tabComplete.js
@@ -5,9 +5,9 @@ const constants = require('./constants')
 const emojiList = Object.keys(emojis.emoji).map(e => `:${e}:`)
 
 const author = (partial) => core.authors.get()
-    .map(nameMap => nameMap.get('name'))
-    .filter(name => name.startsWith(partial))
-    .toArray()
+  .map(nameMap => nameMap.get('name'))
+  .filter(name => name.startsWith(partial))
+  .toArray()
 
 const command = (partial) => constants.COMMANDS.filter(cmd => cmd.startsWith(partial))
 

--- a/util/ui/renderer.js
+++ b/util/ui/renderer.js
@@ -69,7 +69,7 @@ const render = (m) => {
   if (m.get('action')) {
     renderedText = tc.bold[m.get('fromMe') ? 'green' : color(m.get('author'))](renderedText)
   }
-  
+
   const time = tc.gray.dim(formatTime(m.get('timestamp'), constants.TIME_FORMAT))
   const author = () => tc.bold[m.get('fromMe') ? 'green' : color(m.get('author'))](m.get('authorName')())
   const text = () => highlightMentions(renderedText)


### PR DESCRIPTION
Nothing substantial, just making sure `npm test` passes. The only non-trivial change was to add `return` to `core.commands.quit()`, which is never actually even looked at. It *does*, however, pass the linter. :upside_down_face: 